### PR TITLE
fix: add missing pagination flags

### DIFF
--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -578,6 +578,7 @@ func GetCmdListContractsByCreator() *cobra.Command {
 		SilenceUsage: true,
 	}
 	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "list contracts by creator")
 	return cmd
 }
 


### PR DESCRIPTION
Add missing pagination flags to the wasm list-contracts-by-creator cli query