### PR TITLE
Check code hash before gzipping the file

### DIFF
--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -53,7 +54,11 @@ func GenesisStoreCodeCmd(defaultNodeHome string, genesisMutator GenesisMutator) 
 				return err
 			}
 
-			msg, err := parseStoreCodeArgs(args[0], senderAddr, cmd.Flags())
+			wasmFile, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			msg, err := parseStoreCodeArgs(wasmFile, senderAddr, cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -34,7 +35,15 @@ func ProposalStoreCodeCmd() *cobra.Command {
 				return err
 			}
 
-			src, err := parseStoreCodeArgs(args[0], clientCtx.FromAddress, cmd.Flags())
+			wasmFile, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			source, builder, codeHash, err := parseVerificationFlags(wasmFile, cmd.Flags())
+			if err != nil {
+				return err
+			}
+			src, err := parseStoreCodeArgs(wasmFile, clientCtx.FromAddress, cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -51,10 +60,6 @@ func ProposalStoreCodeCmd() *cobra.Command {
 				return err
 			}
 
-			source, builder, codeHash, err := parseVerificationFlags(src.WASMByteCode, cmd.Flags())
-			if err != nil {
-				return err
-			}
 			content := types.StoreCodeProposal{
 				Title:                 proposalTitle,
 				Description:           proposalDescr,
@@ -211,7 +216,15 @@ func ProposalStoreAndInstantiateContractCmd() *cobra.Command {
 				return err
 			}
 
-			src, err := parseStoreCodeArgs(args[0], clientCtx.FromAddress, cmd.Flags())
+			wasmFile, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			source, builder, codeHash, err := parseVerificationFlags(wasmFile, cmd.Flags())
+			if err != nil {
+				return err
+			}
+			src, err := parseStoreCodeArgs(wasmFile, clientCtx.FromAddress, cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -224,11 +237,6 @@ func ProposalStoreAndInstantiateContractCmd() *cobra.Command {
 			}
 
 			unpinCode, err := cmd.Flags().GetBool(flagUnpinCode)
-			if err != nil {
-				return err
-			}
-
-			source, builder, codeHash, err := parseVerificationFlags(src.WASMByteCode, cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/x/wasm/client/cli/gov_tx_test.go
+++ b/x/wasm/client/cli/gov_tx_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func TestParseAccessConfigUpdates(t *testing.T) {
@@ -155,4 +156,25 @@ func TestParseCodeInfoFlags(t *testing.T) {
 			require.NoError(t, gotErr)
 		})
 	}
+}
+
+func TestChecksumGzipInteraction(t *testing.T) {
+	correctSource := "https://github.com/CosmWasm/wasmd/blob/main/x/wasm/keeper/testdata/hackatom.wasm"
+	correctBuilderRef := "cosmwasm/workspace-optimizer:0.12.9"
+
+	fileName := "../../keeper/testdata/hackatom.wasm"
+	wasmFile, err := os.ReadFile(fileName)
+	require.NoError(t, err)
+
+	checksumStr := "13a1fc994cc6d1c81b746ee0c0ff6f90043875e0bf1d9be6b7d779fc978dc2a5"
+	args := []string{"--code-source-url=" + correctSource, "--builder=" + correctBuilderRef, "--code-hash=" + checksumStr}
+
+	flags := ProposalStoreCodeCmd().Flags()
+	require.NoError(t, flags.Parse(args))
+	_, _, _, err = parseVerificationFlags(wasmFile, flags)
+	require.NoError(t, err)
+	msg, err := parseStoreCodeArgs(wasmFile, sdk.AccAddress{}, flags)
+	require.NoError(t, err)
+	_, _, _, err = parseVerificationFlags(msg.WASMByteCode, flags)
+	require.Error(t, err)
 }

--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -81,7 +81,11 @@ func StoreCodeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			msg, err := parseStoreCodeArgs(args[0], clientCtx.GetFromAddress(), cmd.Flags())
+			wasmFile, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			msg, err := parseStoreCodeArgs(wasmFile, clientCtx.GetFromAddress(), cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -101,13 +105,9 @@ func StoreCodeCmd() *cobra.Command {
 	return cmd
 }
 
-func parseStoreCodeArgs(file string, sender sdk.AccAddress, flags *flag.FlagSet) (types.MsgStoreCode, error) {
-	wasm, err := os.ReadFile(file)
-	if err != nil {
-		return types.MsgStoreCode{}, err
-	}
-
+func parseStoreCodeArgs(wasm []byte, sender sdk.AccAddress, flags *flag.FlagSet) (types.MsgStoreCode, error) {
 	// gzip the wasm file
+	var err error
 	if ioutils.IsWasm(wasm) {
 		wasm, err = ioutils.GzipIt(wasm)
 


### PR DESCRIPTION
This fix was introduced in [osmosis'](https://github.com/osmosis-labs/wasmd/pull/15) fork of wasmd.
The bug is also reported [here](https://github.com/CosmWasm/wasmvm/issues/359)

There's a bug upstream that prevents users from creating proposals via the CLI.

The CLI gzips the file before uploading it to the chain and then checks the checksum after gzipping the file, while the chain (wasmvm) unzips the wasm file first and then checks the checksum.

This prevents code proposals from being uploaded via the CLI since neither checksum will validate in both places.

I've changed it so that the checksum check happens on the unzipped wasm code. This is the most natural as it is what developers will see when running sha256sum on the shell and it's also what rust-optimizer outputs.