### PR TITLE
Remove unnecessary check during add-warm-message command

### DIFF
--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -181,10 +181,6 @@ func GenesisExecuteContractCmd(defaultNodeHome string, genesisMutator GenesisMut
 					return errors.New("sender has not enough account balance")
 				}
 
-				// - does contract address exists?
-				if !hasContract(state, msg.Contract) {
-					return fmt.Errorf("unknown contract: %s", msg.Contract)
-				}
 				state.GenMsgs = append(state.GenMsgs, types.GenesisState_GenMsgs{
 					Sum: &types.GenesisState_GenMsgs_ExecuteContract{ExecuteContract: &msg},
 				})

--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -173,14 +173,6 @@ func GenesisExecuteContractCmd(defaultNodeHome string, genesisMutator GenesisMut
 			}
 
 			return genesisMutator.AlterWasmModuleState(cmd, func(state *types.GenesisState, appState map[string]json.RawMessage) error {
-				// simple sanity check that sender has some balance, although it may be consumed by appState previous message already
-				switch ok, err := hasAccountBalance(cmd, appState, senderAddr, msg.Funds); {
-				case err != nil:
-					return err
-				case !ok:
-					return errors.New("sender has not enough account balance")
-				}
-
 				state.GenMsgs = append(state.GenMsgs, types.GenesisState_GenMsgs{
 					Sum: &types.GenesisState_GenMsgs_ExecuteContract{ExecuteContract: &msg},
 				})

--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -354,24 +354,6 @@ func hasAccountBalance(cmd *cobra.Command, appState map[string]json.RawMessage, 
 	return true, nil
 }
 
-func hasContract(state *types.GenesisState, contractAddr string) bool {
-	for _, c := range state.Contracts {
-		if c.ContractAddress == contractAddr {
-			return true
-		}
-	}
-	seq := contractSeqValue(state)
-	for _, m := range state.GenMsgs {
-		if msg := m.GetInstantiateContract(); msg != nil {
-			if keeper.BuildContractAddressClassic(msg.CodeID, seq).String() == contractAddr {
-				return true
-			}
-			seq++
-		}
-	}
-	return false
-}
-
 // GenesisData contains raw and unmarshalled data from the genesis file
 type GenesisData struct {
 	GenesisFile     string

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -506,35 +506,6 @@ func TestExecuteContractCmd(t *testing.T) {
 			},
 			expMsgCount: 1,
 		},
-		"fails without enough sender balance": {
-			srcGenesis: types.GenesisState{
-				Params: types.DefaultParams(),
-				Codes: []types.Code{
-					{
-						CodeID:    1,
-						CodeInfo:  types.CodeInfoFixture(),
-						CodeBytes: wasmIdent,
-					},
-				},
-				Contracts: []types.Contract{
-					{
-						ContractAddress: firstContractAddress,
-						ContractInfo:    types.ContractInfoFixture(),
-						ContractState:   []types.Model{},
-						ContractCodeHistory: []types.ContractCodeHistoryEntry{
-							types.ContractCodeHistoryEntryFixture(),
-						},
-					},
-				},
-			},
-			mutator: func(cmd *cobra.Command) {
-				cmd.SetArgs([]string{firstContractAddress, `{}`})
-				flagSet := cmd.Flags()
-				flagSet.Set("run-as", keeper.RandomBech32AccountAddress(t))
-				flagSet.Set("amount", "10stake")
-			},
-			expError: true,
-		},
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -364,9 +364,6 @@ func TestInstantiateContractCmd(t *testing.T) {
 
 func TestExecuteContractCmd(t *testing.T) {
 	const firstContractAddress = "cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr"
-	minimalWasmGenesis := types.GenesisState{
-		Params: types.DefaultParams(),
-	}
 	anyValidWasmFile, err := os.CreateTemp(t.TempDir(), "wasm")
 	require.NoError(t, err)
 	anyValidWasmFile.Write(wasmIdent)
@@ -451,15 +448,6 @@ func TestExecuteContractCmd(t *testing.T) {
 				flagSet.Set("run-as", myWellFundedAccount)
 			},
 			expMsgCount: 2,
-		},
-		"fails with unknown contract address": {
-			srcGenesis: minimalWasmGenesis,
-			mutator: func(cmd *cobra.Command) {
-				cmd.SetArgs([]string{keeper.RandomBech32AccountAddress(t), `{}`})
-				flagSet := cmd.Flags()
-				flagSet.Set("run-as", myWellFundedAccount)
-			},
-			expError: true,
 		},
 		"succeeds with unknown account when no funds": {
 			srcGenesis: types.GenesisState{


### PR DESCRIPTION
This PR removes a couple of checks during `add-wam-message execute` command:
* `hasContract` check is useless in a case of complex contract instantiation during genesis. For example, when `instantiate-contract` (or `execute`) message populates another contract instantiation during its work. The function is not able to properly build contract address for such contract because of instance id inconsistency, that's why we decided to remove this check;
* `hasAccountBalance` since it cannot properly check balance on consumer chains since there is no `staking` module anymore.