### PR TITLE
bump go version to v1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
 
 commands:
   make:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/CosmWasm/wasmd/tree/HEAD)
 
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.31.0...HEAD)
+- Upgrade to Go v1.20
 
 ## [v0.31.0](https://github.com/CosmWasm/wasmd/tree/v0.31.0) (2023-03-13)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t cosmwasm/wasmd:latest
 # docker run --rm -it cosmwasm/wasmd:latest /bin/sh
-FROM golang:1.19-alpine3.15 AS go-builder
+FROM golang:1.20-alpine3.15 AS go-builder
 ARG arch=x86_64
 
 # this comes from standard alpine nightly file

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This code was forked from the `cosmos/gaia` repository as a basis and then we ad
 many gaia-specific files. However, the `wasmd` binary should function just like `gaiad` except for the
 addition of the `x/wasm` module.
 
-**Note**: Requires [Go 1.19+](https://golang.org/dl/)
+**Note**: Requires [Go 1.20+](https://golang.org/dl/)
 
 For critical security issues & disclosure, see [SECURITY.md](SECURITY.md).
 ## Compatibility with CosmWasm contracts

--- a/contrib/prototools-docker/Dockerfile
+++ b/contrib/prototools-docker/Dockerfile
@@ -39,7 +39,7 @@ RUN GO111MODULE=on go get \
 
 RUN upx --lzma /usr/local/bin/*
 
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 ENV LD_LIBRARY_PATH=/lib64:/lib
 
 WORKDIR /work

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CosmWasm/wasmd
 
-go 1.19
+go 1.20
 
 require (
 	github.com/CosmWasm/wasmvm v1.2.1


### PR DESCRIPTION
A deprecation in the math/rand package in Go v1.20 is causing some of our simulation tests(especially when interacting with wasmd) to randomly generate negative block time. [Go v1.20 release notes](https://go.dev/doc/go1.20)

I followed practices from [previous go version bumps](https://github.com/CosmWasm/wasmd/commit/fc476aa886cc1df488c3dda3c543f23e57bac19d#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) and applied them here for Go v1.20