### PR TITLE
Chore: keep dex message evts [NTRN-439]

### DIFF
--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -237,12 +237,23 @@ func isIBCEvent(event sdk.Event) bool {
 	return false
 }
 
+func isDexEvent(event sdk.Event) bool {
+	for _, attr := range event.Attributes {
+		// Indexing of dex events requires that all dev events are emitted
+		if attr.Key == sdk.AttributeKeyModule && attr.Value == "dex" {
+			return true
+		}
+	}
+	return false
+}
+
 func filterEvents(events []sdk.Event) []sdk.Event {
 	// pre-allocate space for efficiency
 	res := make([]sdk.Event, 0, len(events))
 	for _, ev := range events {
 		// we filter out all 'message' type events but if they are ibc events we must keep them for the IBC relayer (hermes particularly)
-		if ev.Type != "message" || isIBCEvent(ev) {
+		// we also keep dex events, this is required for proper indexing of dex messages
+		if ev.Type != "message" || isIBCEvent(ev) || isDexEvent(ev) {
 			res = append(res, ev)
 		}
 	}

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -404,6 +404,7 @@ func TestDispatchSubmessages(t *testing.T) {
 						// we still emit this to the client, but not the contract
 						sdk.NewEvent("non-determinstic"),
 						sdk.NewEvent("message", sdk.NewAttribute("module", "ibc_channel")),
+						sdk.NewEvent("message", sdk.NewAttribute("module", "dex")),
 					}
 					return events, [][]byte{[]byte("subData")}, [][]*codectypes.Any{}, nil
 				},
@@ -413,6 +414,7 @@ func TestDispatchSubmessages(t *testing.T) {
 			expEvents: []sdk.Event{
 				sdk.NewEvent("non-determinstic"),
 				sdk.NewEvent("message", sdk.NewAttribute("module", "ibc_channel")),
+				sdk.NewEvent("message", sdk.NewAttribute("module", "dex")),
 				// the event from reply is also exposed
 				sdk.NewEvent("stargate-reply"),
 			},


### PR DESCRIPTION
Don't filter dex events. When dex messages are dispatched from CW contracts the "message" events are filtered out. These events must be emitted for proper dex indexing. 